### PR TITLE
Classy frontend

### DIFF
--- a/skyportal/handlers/api/classification.py
+++ b/skyportal/handlers/api/classification.py
@@ -117,8 +117,16 @@ class ClassificationHandler(BaseHandler):
         if not isinstance(taxonomy, list):
             return self.error('Problem retrieving taxonomy')
 
-        if (data['classification'] not in
-            [c["class"] for c in taxonomy[0].allowed_classes]):
+
+        def allowed_classes(hierarchy):
+            if "class" in hierarchy:
+                yield hierarchy["class"]
+
+            if "subclasses" in hierarchy:
+                for item in hierarchy.get("subclasses", []):
+                    yield from allowed_classes(item)
+
+        if data['classification'] not in allowed_classes(taxonomy[0].hierarchy):
             return self.error(f"That classification ({data['classification']}) "
                               'is not in the allowed classes for the chosen '
                               f'taxonomy (id={taxonomy_id}')

--- a/skyportal/handlers/api/taxonomy.py
+++ b/skyportal/handlers/api/taxonomy.py
@@ -175,38 +175,6 @@ class TaxonomyHandler(BaseHandler):
 
         provenance = data.get('provenance', None)
 
-        # The following function and for loop
-        # generates the list of allowed classes for this hierarchy,
-        # capturing both the leaf nodes as well as the parent nodes as
-        # possible classes. In addition, it generates a label to be show
-        # during the selection process. Eg, the output is:
-        #  [{"class": "SN", "label": "<b>SN</br>⇦Cataclysmic"},
-        #   {"class": "Ia", "label": "<b>Ia</br>⇦SN⇦Cataclysmic"}]
-        # The Classification selection on the Source page then uses array
-        # to allow the user to find the classification more easily
-        # using <Autocomplete> from MUI.
-        result = []
-
-        def dict_path(path, my_dict):
-            if my_dict.get("class"):
-                cla = my_dict.get("class")
-                if cla == 'Time-domain Source':
-                    cla = ''
-                result.append(path + "-><b>" + cla + "</b>")
-                for i, item in enumerate(my_dict.get("subclasses", [])):
-                    if isinstance(item, dict):
-                        dict_path(path + "->" + cla, item)
-
-        dict_path("", hierarchy)
-        allowed_classes = []
-        for value in result:
-            classpath = value.split("->")[2:]
-            if len(classpath) > 0:
-                allowed_classes.append({
-                    "class": classpath[-1].split(">")[1].split("<")[0],
-                    "label": "⇐".join(list(reversed(classpath)))
-                })
-
         # update others with this name
         # TODO: deal with the same name but different groups?
         isLatest = data.get('isLatest', True)
@@ -219,7 +187,6 @@ class TaxonomyHandler(BaseHandler):
             name=name,
             hierarchy=hierarchy,
             provenance=provenance,
-            allowed_classes=allowed_classes,
             version=version,
             isLatest=isLatest,
             groups=groups

--- a/skyportal/models.py
+++ b/skyportal/models.py
@@ -513,11 +513,6 @@ class Taxonomy(Base):
                         doc='Semantic version of this taxonomy'
                         )
 
-    allowed_classes = sa.Column(JSONB, nullable=False,
-                                doc="Computed list of allowable classes"
-                                " in this taxonomy, like "
-                                " [{'class': 'II', 'label': 'II<SNII'}, ...]")
-
     isLatest = sa.Column(sa.Boolean, default=True, nullable=False,
                          doc='Consider this the latest version of '
                              'the taxonomy with this name? Defaults '

--- a/static/js/components/ClassificationForm.jsx
+++ b/static/js/components/ClassificationForm.jsx
@@ -11,6 +11,8 @@ import { showNotification } from "baselayer/components/Notifications";
 import * as Actions from '../ducks/source';
 
 
+// For each node in the hierarchy tree, add its full path from root
+// to the node_paths list
 const add_node_paths = (node_paths, hierarchy, prefix_path=[]) => {
   const this_node_path = [...prefix_path];
 
@@ -28,6 +30,8 @@ const add_node_paths = (node_paths, hierarchy, prefix_path=[]) => {
 };
 
 
+// For each class in the hierarchy, return its name
+// as well as the path from the root of hierarchy to that class
 const allowed_classes = (hierarchy) => {
   const class_paths = [];
   add_node_paths(class_paths, hierarchy);
@@ -167,6 +171,8 @@ const ClassificationForm = ({ obj_id, taxonomyList }) => {
               /* eslint-disable-next-line react/jsx-props-no-spreading */
               renderInput={(params) => <TextField {...params} style={{ width: '100%' }} label="Classification" fullWidth />}
               renderOption={
+                // Note: these come from "options", which in turn come from state.allowed_classes
+                // See the allowed_classes function defined above
                 (option) => (
                   <span>
                     <b>{ option.class }</b>


### PR DESCRIPTION
Compute available options in JS and node paths as a Python generator.

This allows us to avoid storing interim computed results in the database, and avoids generating HTML on the Python backend.